### PR TITLE
add vendor and repsitory metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Forked from `rpm-rs` at version 0.8.1.
+- Added vendor and repository optional fields to `RPMBuilder`.
 
 ### Fixed
 - Take dependabot updates

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ let pkg = rpm::RPMBuilder::new("test", "1.0.0", "MIT", "x86_64", "some awesome p
             .add_changelog_entry("you", "yeah, it was", 12312312)
             .requires(Dependency::any("wget"))
             .build_and_sign(Signer::load_from_asc_bytes(&raw_secret_key)?)
+            .vendor("corporation or individual")
+            .repository("www.github.com/repo")
 let mut f = std::fs::File::create("./awesome.rpm")?;
 pkg.write(&mut f)?;
 

--- a/src/rpm/builder.rs
+++ b/src/rpm/builder.rs
@@ -78,6 +78,9 @@ pub struct RPMBuilder {
     changelog_entries: Vec<String>,
     changelog_times: Vec<i32>,
     compressor: Compressor,
+
+    vendor: Option<String>,
+    repository: Option<String>,
 }
 
 impl RPMBuilder {
@@ -106,7 +109,18 @@ impl RPMBuilder {
             changelog_times: Vec::new(),
             compressor: Compressor::None(Vec::new()),
             directories: BTreeSet::new(),
+            vendor: None,
+            repository: None,
         }
+    }
+
+    pub fn vendor<T: Into<String>>(mut self, content: T) -> Self {
+        self.vendor = Some(content.into());
+        self
+    }
+    pub fn repository<T: Into<String>>(mut self, content: T) -> Self {
+        self.repository = Some(content.into());
+        self
     }
 
     pub fn epoch(mut self, epoch: i32) -> Self {
@@ -880,6 +894,22 @@ impl RPMBuilder {
                 IndexTag::RPMTAG_POSTUN,
                 offset,
                 IndexData::StringTag(self.post_uninst_script.unwrap()),
+            ));
+        }
+
+        if self.vendor.is_some() {
+            actual_records.push(IndexEntry::new(
+                IndexTag::RPMTAG_VENDOR,
+                offset,
+                IndexData::StringTag(self.vendor.unwrap()),
+            ));
+        }
+
+        if self.repository.is_some() {
+            actual_records.push(IndexEntry::new(
+                IndexTag::RPMTAG_URL,
+                offset,
+                IndexData::StringTag(self.repository.unwrap()),
             ));
         }
 


### PR DESCRIPTION
I was hoping to add more fields to rpm metadata for use with cargo-generate-rpm. This merge adds vendor and repository as options for inclusion in metadata.